### PR TITLE
Adding CPU as one of the file paths keyword to get temp

### DIFF
--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
+grep -E 'Tctl|Tdie|Package id|CPU' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
 
 # Following script outputs current cpu die temperature in milidegree-celcius, convert it to celcius and fahrenheit and display as:
 #


### PR DESCRIPTION
Adding CPU word in the CPU-temperature script which is used in some older laptop as a label for the CPU temperature